### PR TITLE
Romanian VAT rate has changed to 20% as of 1/Jan/2016

### DIFF
--- a/rates.json
+++ b/rates.json
@@ -3,6 +3,14 @@
     "disclaimer": "This data is compiled from official European Commission sources to be as accurate as possible, however no guarantee of accuracy is provided. Use at your own risk. Don't trust random people on the internet without doing your own research.",
     
     "rates": {
+        "AT": {
+            "country": "Austria",
+            "standard_rate": 20.00,
+            "reduced_rate": 10.00,
+            "reduced_rate_alt": 13.00,
+            "super_reduced_rate": false,
+            "parking_rate": 12.00
+        },
         "BE": {
             "country": "Belgium",
             "standard_rate": 21.00,
@@ -19,11 +27,19 @@
             "super_reduced_rate": false,
             "parking_rate": false
         },
+        "CY": {
+            "country": "Cyprus",
+            "standard_rate": 19.00,
+            "reduced_rate": 9.00,
+            "reduced_rate_alt": 5.00,
+            "super_reduced_rate": false,
+            "parking_rate": false
+        },
         "CZ": {
             "country": "Czech Republic",
             "standard_rate": 21.00,
             "reduced_rate": 15.00,
-            "reduced_rate_alt": false,
+            "reduced_rate_alt": 10.00,
             "super_reduced_rate": false,
             "parking_rate": false
         },
@@ -54,7 +70,6 @@
         "EL": {
             "_comment": "While the EU uses the country code 'EL' for Greece, ISO uses 'GR' - both are included for convenience.",
             "iso_duplicate": "GR",
-
             "country": "Greece",
             "standard_rate": 23.00,
             "reduced_rate": 13.00,
@@ -65,7 +80,6 @@
         "GR": {
             "_comment": "Duplicate of EL for convenience; the EU uses the country code 'EL' for Greece, while ISO uses 'GR'.",
             "iso_duplicate_of": "EL",
-
             "country": "Greece",
             "standard_rate": 23.00,
             "reduced_rate": 13.00,
@@ -79,6 +93,14 @@
             "reduced_rate": 10.00,
             "reduced_rate_alt": false,
             "super_reduced_rate": 4.00,
+            "parking_rate": false
+        },
+        "FI": {
+            "country": "Finland",
+            "standard_rate": 24.00,
+            "reduced_rate": 14.00,
+            "reduced_rate_alt": 10.00,
+            "super_reduced_rate": false,
             "parking_rate": false
         },
         "FR": {
@@ -97,27 +119,11 @@
             "super_reduced_rate": false,
             "parking_rate": false
         },
-        "IE": {
-            "country": "Ireland",
-            "standard_rate": 23.00,
-            "reduced_rate": 13.50,
-            "reduced_rate_alt": 9.00,
-            "super_reduced_rate": 4.80,
-            "parking_rate": 13.50
-        },
         "IT": {
             "country": "Italy",
             "standard_rate": 22.00,
             "reduced_rate": 10.00,
             "reduced_rate_alt": 4.00,
-            "super_reduced_rate": false,
-            "parking_rate": false
-        },
-        "CY": {
-            "country": "Cyprus",
-            "standard_rate": 19.00,
-            "reduced_rate": 9.00,
-            "reduced_rate_alt": 5.00,
             "super_reduced_rate": false,
             "parking_rate": false
         },
@@ -153,6 +159,14 @@
             "super_reduced_rate": false,
             "parking_rate": false
         },
+        "IE": {
+            "country": "Ireland",
+            "standard_rate": 23.00,
+            "reduced_rate": 13.50,
+            "reduced_rate_alt": 9.00,
+            "super_reduced_rate": 4.80,
+            "parking_rate": 13.50
+        },
         "MT": {
             "country": "Malta",
             "standard_rate": 18.00,
@@ -168,14 +182,6 @@
             "reduced_rate_alt": false,
             "super_reduced_rate": false,
             "parking_rate": false
-        },
-        "AT": {
-            "country": "Austria",
-            "standard_rate": 20.00,
-            "reduced_rate": 10.00,
-            "reduced_rate_alt": false,
-            "super_reduced_rate": false,
-            "parking_rate": 12.00
         },
         "PL": {
             "country": "Poland",
@@ -195,7 +201,7 @@
         },
         "RO": {
             "country": "Romania",
-            "standard_rate": 24.00,
+            "standard_rate": 20.00,
             "reduced_rate": 9.00,
             "reduced_rate_alt": 5.00,
             "super_reduced_rate": false,
@@ -217,14 +223,6 @@
             "super_reduced_rate": false,
             "parking_rate": false
         },
-        "FI": {
-            "country": "Finland",
-            "standard_rate": 24.00,
-            "reduced_rate": 14.00,
-            "reduced_rate_alt": 10.00,
-            "super_reduced_rate": false,
-            "parking_rate": false
-        },
         "SE": {
             "country": "Sweden",
             "standard_rate": 25.00,
@@ -236,7 +234,6 @@
         "UK": {
             "_comment": "While the EU uses the country code 'UK' for the United Kingdom, ISO uses 'GB' - both are included for convenience.",
             "iso_duplicate": "GB",
-
             "country": "United Kingdom",
             "standard_rate": 20.00,
             "reduced_rate": 5.00,
@@ -247,7 +244,6 @@
         "GB": {
             "_comment": "Duplicate of GB for convenience; the EU uses the country code 'UK' for the United Kingdom, while ISO uses 'GB'.",
             "iso_duplicate_of": "UK",
-
             "country": "United Kingdom",
             "standard_rate": 20.00,
             "reduced_rate": 5.00,


### PR DESCRIPTION
Romanian VAT rate has changed to 20% as of 1/Jan/2016; and there was a missing Czech reduced rate. I have synchronised the rates with those at http://www.vatlive.com/vat-rates/european-vat-rates/eu-vat-rates/ as of 1-Jan-2016. I also changed some of the ordering to be closer to that list, where the ordering was unnatural (i.e. not alphabetical on either country code or country name).