### PR TITLE
Add VAT names

### DIFF
--- a/rates.json
+++ b/rates.json
@@ -5,6 +5,8 @@
     "rates": {
         "AT": {
             "country": "Austria",
+            "vat_name": "Umsatzsteuer",
+            "vat_abbr": "USt",
             "standard_rate": 20.00,
             "reduced_rate": 10.00,
             "reduced_rate_alt": 13.00,
@@ -13,6 +15,8 @@
         },
         "BE": {
             "country": "Belgium",
+            "vat_name": "Taxe sur la valeur ajoutée",
+            "vat_abbr": "TVA/BTW",
             "standard_rate": 21.00,
             "reduced_rate": 12.00,
             "reduced_rate_alt": 6.00,
@@ -21,6 +25,8 @@
         },
         "BG": {
             "country": "Bulgaria",
+            "vat_name": "Dana Dobavena Stoynost",
+            "vat_abbr": "DDS",
             "standard_rate": 20.00,
             "reduced_rate": 9.00,
             "reduced_rate_alt": false,
@@ -29,6 +35,8 @@
         },
         "CY": {
             "country": "Cyprus",
+            "vat_name": "Foros prostithemenis axias",
+            "vat_abbr": "FPA",
             "standard_rate": 19.00,
             "reduced_rate": 9.00,
             "reduced_rate_alt": 5.00,
@@ -37,6 +45,8 @@
         },
         "CZ": {
             "country": "Czech Republic",
+            "vat_name": "Dani z pridane hotnoty",
+            "vat_abbr": "DPH",
             "standard_rate": 21.00,
             "reduced_rate": 15.00,
             "reduced_rate_alt": 10.00,
@@ -45,6 +55,8 @@
         },
         "DK": {
             "country": "Denmark",
+            "vat_name": "Omsaetningsavgift",
+            "vat_abbr": "MOMS",
             "standard_rate": 25.00,
             "reduced_rate": false,
             "reduced_rate_alt": false,
@@ -53,6 +65,8 @@
         },
         "DE": {
             "country": "Germany",
+            "vat_name": "Umsatzsteuer",
+            "vat_abbr": "USt",
             "standard_rate": 19.00,
             "reduced_rate": 7.00,
             "reduced_rate_alt": false,
@@ -61,6 +75,8 @@
         },
         "EE": {
             "country": "Estonia",
+            "vat_name": "Käibemaks",
+            "vat_abbr": "KMKR",
             "standard_rate": 20.00,
             "reduced_rate": 9.00,
             "reduced_rate_alt": false,
@@ -71,6 +87,8 @@
             "_comment": "While the EU uses the country code 'EL' for Greece, ISO uses 'GR' - both are included for convenience.",
             "iso_duplicate": "GR",
             "country": "Greece",
+            "vat_name": "Foros prostithemenis axias",
+            "vat_abbr": "FPA",
             "standard_rate": 23.00,
             "reduced_rate": 13.00,
             "reduced_rate_alt": 6.00,
@@ -81,6 +99,8 @@
             "_comment": "Duplicate of EL for convenience; the EU uses the country code 'EL' for Greece, while ISO uses 'GR'.",
             "iso_duplicate_of": "EL",
             "country": "Greece",
+            "vat_name": "Foros prostithemenis axias",
+            "vat_abbr": "FPA",
             "standard_rate": 23.00,
             "reduced_rate": 13.00,
             "reduced_rate_alt": 6.00,
@@ -89,6 +109,8 @@
         },
         "ES": {
             "country": "Spain",
+            "vat_name": "Impuesto sobre el valor añadido",
+            "vat_abbr": "IVA",
             "standard_rate": 21.00,
             "reduced_rate": 10.00,
             "reduced_rate_alt": false,
@@ -97,6 +119,8 @@
         },
         "FI": {
             "country": "Finland",
+            "vat_name": "Arvonlisävero",
+            "vat_abbr": "AVL",
             "standard_rate": 24.00,
             "reduced_rate": 14.00,
             "reduced_rate_alt": 10.00,
@@ -105,6 +129,8 @@
         },
         "FR": {
             "country": "France",
+            "vat_name": "Taxe sur la valeur ajoutée",
+            "vat_abbr": "TVA",
             "standard_rate": 20.00,
             "reduced_rate": 10.00,
             "reduced_rate_alt": 5.50,
@@ -113,6 +139,8 @@
         },
         "HR": {
             "country": "Croatia",
+            "vat_name": "Porez na dodanu vrijednost",
+            "vat_abbr": "PDV",
             "standard_rate": 25.00,
             "reduced_rate": 13.00,
             "reduced_rate_alt": 5.00,
@@ -121,6 +149,8 @@
         },
         "IT": {
             "country": "Italy",
+            "vat_name": "Imposta sul valore aggiunto",
+            "vat_abbr": "IVA",
             "standard_rate": 22.00,
             "reduced_rate": 10.00,
             "reduced_rate_alt": 4.00,
@@ -129,6 +159,8 @@
         },
         "LV": {
             "country": "Latvia",
+            "vat_name": "Pievienotas vertibas nodoklis",
+            "vat_abbr": "PVN",
             "standard_rate": 21.00,
             "reduced_rate": 12.00,
             "reduced_rate_alt": false,
@@ -137,6 +169,8 @@
         },
         "LT": {
             "country": "Lithuania",
+            "vat_name": "Pridetines vertes mokestis",
+            "vat_abbr": "PVM",
             "standard_rate": 21.00,
             "reduced_rate": 9.00,
             "reduced_rate_alt": 5.00,
@@ -145,6 +179,8 @@
         },
         "LU": {
             "country": "Luxembourg",
+            "vat_name": "Taxe sur la valeur ajoutée",
+            "vat_abbr": "TVA",
             "standard_rate": 17.00,
             "reduced_rate": 14.00,
             "reduced_rate_alt": 8.00,
@@ -153,6 +189,8 @@
         },
         "HU": {
             "country": "Hungary",
+            "vat_name": "Általános forgalmi adó",
+            "vat_abbr": "AFA",
             "standard_rate": 27.00,
             "reduced_rate": 18.00,
             "reduced_rate_alt": 5.00,
@@ -161,6 +199,8 @@
         },
         "IE": {
             "country": "Ireland",
+            "vat_name": "Value added tax",
+            "vat_abbr": "VAT",
             "standard_rate": 23.00,
             "reduced_rate": 13.50,
             "reduced_rate_alt": 9.00,
@@ -169,6 +209,8 @@
         },
         "MT": {
             "country": "Malta",
+            "vat_name": "Value added tax",
+            "vat_abbr": "VAT",
             "standard_rate": 18.00,
             "reduced_rate": 7.00,
             "reduced_rate_alt": 5.00,
@@ -177,6 +219,8 @@
         },
         "NL": {
             "country": "Netherlands",
+            "vat_name": "Omzetbelasting",
+            "vat_abbr": "OB",
             "standard_rate": 21.00,
             "reduced_rate": 6.00,
             "reduced_rate_alt": false,
@@ -185,6 +229,8 @@
         },
         "PL": {
             "country": "Poland",
+            "vat_name": "Podatek od towaròw i uslug",
+            "vat_abbr": "VAT",
             "standard_rate": 23.00,
             "reduced_rate": 8.00,
             "reduced_rate_alt": 5.00,
@@ -193,6 +239,8 @@
         },
         "PT": {
             "country": "Portugal",
+            "vat_name": "Imposto sobre o valor acrescentado",
+            "vat_abbr": "IVA",
             "standard_rate": 23.00,
             "reduced_rate": 13.00,
             "reduced_rate_alt": 6.00,
@@ -201,6 +249,8 @@
         },
         "RO": {
             "country": "Romania",
+            "vat_name": "Taxa pe valoarea adãugata",
+            "vat_abbr": "TVA",
             "standard_rate": 20.00,
             "reduced_rate": 9.00,
             "reduced_rate_alt": 5.00,
@@ -209,6 +259,8 @@
         },
         "SI": {
             "country": "Slovenia",
+            "vat_name": "Davek na dodano vred nost",
+            "vat_abbr": "DDV",
             "standard_rate": 22.00,
             "reduced_rate": 9.50,
             "reduced_rate_alt": false,
@@ -217,6 +269,8 @@
         },
         "SK": {
             "country": "Slovakia",
+            "vat_name": "Dan z pridanej hodnoty",
+            "vat_abbr": "DPH",
             "standard_rate": 20.00,
             "reduced_rate": 10.00,
             "reduced_rate_alt": false,
@@ -225,6 +279,8 @@
         },
         "SE": {
             "country": "Sweden",
+            "vat_name": "Mervärdeskatt",
+            "vat_abbr": "ML",
             "standard_rate": 25.00,
             "reduced_rate": 12.00,
             "reduced_rate_alt": 6.00,
@@ -235,6 +291,8 @@
             "_comment": "While the EU uses the country code 'UK' for the United Kingdom, ISO uses 'GB' - both are included for convenience.",
             "iso_duplicate": "GB",
             "country": "United Kingdom",
+            "vat_name": "Value added tax",
+            "vat_abbr": "VAT",
             "standard_rate": 20.00,
             "reduced_rate": 5.00,
             "reduced_rate_alt": false,
@@ -245,6 +303,8 @@
             "_comment": "Duplicate of GB for convenience; the EU uses the country code 'UK' for the United Kingdom, while ISO uses 'GB'.",
             "iso_duplicate_of": "UK",
             "country": "United Kingdom",
+            "vat_name": "Value added tax",
+            "vat_abbr": "VAT",
             "standard_rate": 20.00,
             "reduced_rate": 5.00,
             "reduced_rate_alt": false,


### PR DESCRIPTION
To allow adding the local VAT name or abbreviation in invoices, add them to the list.

This allows to show e.g. "Taxes - Umsatzsteuer (USt) - Austria - 20% - 3,33 EUR" or "USt - Austria - 20% - 3,33 EUR" on the invoice, depending on the wishes of invoice creator.

Not every user will understand the English term "Value added tax" or know that his local "Umsatzsteuer" is meant. In addition to being nicer and easier to understand for end users and their accountants, this makes it clearer to the end user that his local tax was applied.

Source: Handelskammer Hamburg (Chamber of commerce of Hamburg, Germany)
https://www.hk24.de/produktmarken/beratung-service/recht_und_steuern/steuerrecht/umsatzsteuer_mehrwertsteuer/umsatzsteuer_mehrwertsteuer_international/warenhandel/umsatzsteuersaetze-eu-drittstaaten/1167702